### PR TITLE
Added ld cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +267,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "criterion",
+ "dynamic-loader-cache",
  "elf_loader",
  "env_logger",
  "gimli 0.30.0",
@@ -272,6 +279,19 @@ dependencies = [
  "phf",
  "spin",
  "unwinding",
+]
+
+[[package]]
+name = "dynamic-loader-cache"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86d81854a863e59689c10e28abcd05efa490b817598fe0ed1d4d8d764240e3d"
+dependencies = [
+ "arrayvec",
+ "memmap2",
+ "nom",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
@@ -458,6 +478,31 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-traits"
@@ -692,6 +737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +751,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ features = ['macros']
 version = "0.4.0"
 default-features = false
 
+[dependencies.dynamic-loader-cache]
+version = "0.2.1"
+optional = true
+
 [dependencies]
 bitflags = "2.6.0"
 cfg-if = '1.0'
@@ -86,6 +90,8 @@ fde-phdr-dl = ["unwinding?/fde-phdr-dl"]
 fde-static = ["unwinding?/fde-static"]
 # see https://github.com/nbdd0121/unwinding/#baremetal
 fde-gnu-eh-frame-hdr = ["unwinding?/fde-gnu-eh-frame-hdr"]
+# enable dynamic loader cache
+ld-cache = ["std", "dep:dynamic-loader-cache"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ default = ["mmap", "tls", "libgcc", "debug"]
 # enable this when you want to use gdb/lldb to debug the loaded dynamic libraries
 debug = ["std"]
 # enable std
-std = ["elf_loader/std", "dep:libc"]
+std = ["elf_loader/std", "dep:libc", "dep:dynamic-loader-cache"]
 # enable default implementation on devices with mmapl storage
 mmap = ["std", "elf_loader/mmap"]
 # enable this when you need to use thread loca
@@ -90,8 +90,6 @@ fde-phdr-dl = ["unwinding?/fde-phdr-dl"]
 fde-static = ["unwinding?/fde-static"]
 # see https://github.com/nbdd0121/unwinding/#baremetal
 fde-gnu-eh-frame-hdr = ["unwinding?/fde-gnu-eh-frame-hdr"]
-# enable dynamic loader cache
-ld-cache = ["std", "dep:dynamic-loader-cache"]
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
Enables processing ld.so.cache.

To parse the cache file, I used the [dynamic-loader-cache](https://crates.io/crates/dynamic-loader-cache) crate. Since I don't know the philosophy behind the project, and whether you want to write your own parser, this feature currently lives behind the `ld-cache` feature flag.

Nice project, I will definitely play with it in the future!