### PR TITLE
There were some messages that were being printed in installed binaries

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -101,8 +101,6 @@ pub(crate) unsafe fn from_raw(
             dynamic.strtab -= base;
             dynamic.symtab -= base;
             dynamic.hashtab -= base;
-            println!("{:?}", name);
-            println!("{:#x}", dynamic.strtab);
             dynamic.version_idx = dynamic
                 .version_idx
                 .map(|v| NonZero::new(v.get() - base).unwrap());


### PR DESCRIPTION
Hi, I noticed that when I ran `cargo install --path .` on any program which ran `dlopen_rs::init()`, running the program would cause something like this to be printed out:

```
""
0x5ba114c4e500
"/usr/lib/libgcc_s.so.1"
0x728811fe12b8
"/usr/lib/libc.so.6"
0x728811e04d00
""
0x5ba114c4e500
"/usr/lib/libgcc_s.so.1"
0x728811fe12b8
"/usr/lib/libc.so.6"
0x728811e04d00
"/lib64/ld-linux-x86-64.so.2"
0x72881203d8a0
```

I managed to track where these messages were coming from, and got rid of them.

Also, when you get rid of these messages, be it by merging this pull request or some other way, would you mind releasing a new version of `dlopen-rs`? I'm gonna release a new version of my crate, and I would like to not have those messages show up in it, since I'm not allowed to use git dependencies in published packages.